### PR TITLE
Fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 	url = https://github.com/NordicSemiconductor/nrfx.git
 [submodule "lib/lv_bindings"]
 	path = lib/lv_bindings
-	url = https://github.com/amirgon/lv_bindings.git
+	url = https://github.com/littlevgl/lv_bindings.git

--- a/lib/lv_conf.h
+++ b/lib/lv_conf.h
@@ -269,7 +269,7 @@ long unsigned int gc_nbytes(const void *ptr);
 #endif
 
 /*Tileview (dependencies: lv_page) */
-#define USE_LV_TILEVIEW     0
+#define USE_LV_TILEVIEW     1
 #if USE_LV_TILEVIEW
 #define LV_TILEVIEW_ANIM_TIME   300     /*Time of slide animation [ms] (0: no animation)*/
 #endif
@@ -291,7 +291,7 @@ long unsigned int gc_nbytes(const void *ptr);
 #define USE_LV_CHART    1
 
 /*Table (dependencies: lv_label)*/
-#define USE_LV_TABLE    0
+#define USE_LV_TABLE    1
 #if USE_LV_TABLE
 #define LV_TABLE_COL_MAX    12
 #endif
@@ -310,7 +310,7 @@ long unsigned int gc_nbytes(const void *ptr);
 #endif
 
 /*Spinbox (dependencies: lv_ta)*/
-#define USE_LV_SPINBOX       0
+#define USE_LV_SPINBOX       1
 
 /*Calendar (dependencies: -)*/
 #define USE_LV_CALENDAR 1
@@ -324,7 +324,7 @@ long unsigned int gc_nbytes(const void *ptr);
 #endif
 
 /*Canvas (dependencies: lv_img)*/
-#define USE_LV_CANVAS       0
+#define USE_LV_CANVAS       1
 /*************************
  * User input objects
  *************************/

--- a/py/py.mk
+++ b/py/py.mk
@@ -120,111 +120,20 @@ $(BUILD)/extmod/modbtree.o: CFLAGS += $(BTREE_DEFS)
 endif
 
 #LittlevGL
-LVGL_BINDING_DIR = lib/lv_bindings
+LVGL_BINDING_DIR = $(TOP)/lib/lv_bindings
 LVGL_DIR = $(LVGL_BINDING_DIR)/lvgl
-INC += -I$(TOP)/$(LVGL_DIR)
-ALL_LVGL_SRC = $(shell find $(TOP)/$(LVGL_DIR) -type f)
-QSTR_GLOBAL_DEPENDENCIES += $(BUILD)/micropython/lv_mpy.c
-$(BUILD)/micropython/lv_mpy.c: $(ALL_LVGL_SRC)
+INC += -I$(LVGL_DIR)
+ALL_LVGL_SRC = $(shell find $(LVGL_DIR) -type f) $(TOP)/lib/lv_conf.h
+LVGL_MPY = $(BUILD)/lvgl/lv_mpy.c
+QSTR_GLOBAL_DEPENDENCIES += $(LVGL_MPY)
+
+$(LVGL_MPY): $(ALL_LVGL_SRC)
 	$(ECHO) "LVGL-GEN $@"
-	$(Q)mkdir -p $(BUILD)/micropython
-	$(Q)$(PYTHON) $(TOP)/$(LVGL_BINDING_DIR)/micropython/gen_mpy.py -X anim -X group -X task $(INC) -I $(TOP)/$(LVGL_BINDING_DIR)/micropython/pycparser/utils/fake_libc_include $(TOP)/$(LVGL_DIR)/lvgl.h > $@
+	$(Q)mkdir -p $(dir $@)
+	$(Q)$(PYTHON) $(LVGL_BINDING_DIR)/micropython/gen_mpy.py -X anim -X group -X task $(INC) -I $(LVGL_BINDING_DIR)/micropython/pycparser/utils/fake_libc_include $(LVGL_DIR)/lvgl.h > $@
 
 CFLAGS_MOD += -Wno-unused-function
-
-
-SRC_MOD += $(BUILD)/micropython/lv_mpy.c \
-    $(addprefix $(LVGL_DIR)/,\
-    lv_core/lv_group.c \
-    lv_core/lv_indev.c \
-    lv_core/lv_obj.c \
-    lv_core/lv_refr.c \
-    lv_core/lv_style.c \
-    lv_core/lv_vdb.c \
-    lv_draw/lv_draw_arc.c \
-    lv_draw/lv_draw.c \
-    lv_draw/lv_draw_img.c \
-    lv_draw/lv_draw_label.c \
-    lv_draw/lv_draw_line.c \
-    lv_draw/lv_draw_rbasic.c \
-    lv_draw/lv_draw_rect.c \
-    lv_draw/lv_draw_triangle.c \
-    lv_draw/lv_draw_vbasic.c \
-    lv_fonts/lv_font_builtin.c \
-    lv_fonts/lv_font_dejavu_10.c \
-    lv_fonts/lv_font_dejavu_10_cyrillic.c \
-    lv_fonts/lv_font_dejavu_10_latin_sup.c \
-    lv_fonts/lv_font_dejavu_20.c \
-    lv_fonts/lv_font_dejavu_20_cyrillic.c \
-    lv_fonts/lv_font_dejavu_20_latin_sup.c \
-    lv_fonts/lv_font_dejavu_30.c \
-    lv_fonts/lv_font_dejavu_30_cyrillic.c \
-    lv_fonts/lv_font_dejavu_30_latin_sup.c \
-    lv_fonts/lv_font_dejavu_40.c \
-    lv_fonts/lv_font_dejavu_40_cyrillic.c \
-    lv_fonts/lv_font_dejavu_40_latin_sup.c \
-    lv_fonts/lv_font_monospace_8.c \
-    lv_fonts/lv_font_symbol_10.c \
-    lv_fonts/lv_font_symbol_20.c \
-    lv_fonts/lv_font_symbol_30.c \
-    lv_fonts/lv_font_symbol_40.c \
-    lv_hal/lv_hal_disp.c \
-    lv_hal/lv_hal_indev.c \
-    lv_hal/lv_hal_tick.c \
-    lv_misc/lv_anim.c \
-    lv_misc/lv_area.c \
-    lv_misc/lv_circ.c \
-    lv_misc/lv_color.c \
-    lv_misc/lv_font.c \
-    lv_misc/lv_fs.c \
-    lv_misc/lv_ll.c \
-    lv_misc/lv_log.c \
-    lv_misc/lv_math.c \
-    lv_misc/lv_mem.c \
-    lv_misc/lv_task.c \
-    lv_misc/lv_templ.c \
-    lv_misc/lv_txt.c \
-    lv_misc/lv_ufs.c \
-    lv_misc/lv_gc.c \
-    lv_objx/lv_arc.c \
-    lv_objx/lv_bar.c \
-    lv_objx/lv_btn.c \
-    lv_objx/lv_btnm.c \
-    lv_objx/lv_calendar.c \
-    lv_objx/lv_cb.c \
-    lv_objx/lv_chart.c \
-    lv_objx/lv_cont.c \
-    lv_objx/lv_ddlist.c \
-    lv_objx/lv_gauge.c \
-    lv_objx/lv_imgbtn.c \
-    lv_objx/lv_img.c \
-    lv_objx/lv_kb.c \
-    lv_objx/lv_label.c \
-    lv_objx/lv_led.c \
-    lv_objx/lv_line.c \
-    lv_objx/lv_list.c \
-    lv_objx/lv_lmeter.c \
-    lv_objx/lv_mbox.c \
-    lv_objx/lv_objx_templ.c \
-    lv_objx/lv_page.c \
-    lv_objx/lv_preload.c \
-    lv_objx/lv_roller.c \
-    lv_objx/lv_slider.c \
-    lv_objx/lv_sw.c \
-    lv_objx/lv_tabview.c \
-    lv_objx/lv_ta.c \
-    lv_objx/lv_win.c \
-    lv_themes/lv_theme_alien.c \
-    lv_themes/lv_theme.c \
-    lv_themes/lv_theme_default.c \
-    lv_themes/lv_theme_material.c \
-    lv_themes/lv_theme_mono.c \
-    lv_themes/lv_theme_nemo.c \
-    lv_themes/lv_theme_night.c \
-    lv_themes/lv_theme_templ.c \
-    lv_themes/lv_theme_zen.c \
-    )
-
+SRC_MOD += $(subst $(TOP)/,,$(shell find $(LVGL_DIR) -type f -name "*.c") $(LVGL_MPY))
 
 # py object files
 PY_CORE_O_BASENAME = $(addprefix py/,\


### PR DESCRIPTION
Point lv_binding to LittlevGL instead of amirgon and update it. Re-enable: USE_LV_TILEVIEW, USE_LV_TABLE, USE_LV_SPINBOX, USE_LV_CANVASUSE_LV_CANVAS (just needed to add their .c file to the Makefile to prevent the linker error). Fix makefile dependencies. Compile all .c file under lvgl instead of specifying them explicitly.